### PR TITLE
fix folder path in completeMessage

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -21,5 +21,5 @@ module.exports = {
       'message': 'Author'
     },
   },
-  completeMessage: '{{#inPlace}}To get started:\n\n  npm install # Or yarn\n  npm run dev{{else}}To get started:\n\n  cd {{destDirName}}\n  npm install # Or yarn\n  npm run dev{{/inPlace}}'
+  completeMessage: '{{#inPlace}}To get started:\n\n  npm install # Or yarn\n  npm run dev{{else}}To get started:\n\n  cd {{destDirName}}/site\n  npm install # Or yarn\n  npm run dev{{/inPlace}}'
 };


### PR DESCRIPTION
The `package.json` lives in the `site` subfolder. running `npm install` in `{{destDirName}}` doesn't seem to work. Running it in `{{destDirName}}/site` does work.