### PR TITLE
Remove the API configuration from the template

### DIFF
--- a/template/nuxtent.config.js
+++ b/template/nuxtent.config.js
@@ -6,11 +6,5 @@ module.exports = {
       'get', 'getAll'
     ],
     isPost: false
-  },
-
-  api: {
-    baseURL: process.env.NODE_ENV === 'production'
-      ? 'http://localhost:3000'
-      : 'http://localhost:3000'
   }
 }


### PR DESCRIPTION
The documenation already covers it quite good
that you might need to adjust it. But usually you just
don't need to do so.

Therefore it is less confusing when it is not included
in the template.