### PR TITLE
Newest version of nuxtent requires api configuration

### DIFF
--- a/template/nuxtent.config.js
+++ b/template/nuxtent.config.js
@@ -6,5 +6,9 @@ module.exports = {
       'get', 'getAll'
     ],
     isPost: false
+  },
+  api: {
+    baseURL: 'http://localhost:3000',
+    browserBaseURL: 'http://localhost:3000'
   }
 }


### PR DESCRIPTION
When starting a new template, every permalink request to a content file fails because of a missing api configuration.

See https://github.com/nuxt-community/nuxtent-module/issues/152